### PR TITLE
Fix configuration binding directly to builders

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationProperties.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationProperties.java
@@ -36,8 +36,6 @@ public class PubSubConfigurationProperties {
 
     public static final String PREFIX = GoogleCloudConfiguration.PREFIX + ".pubsub";
 
-    private  Publisher publisher = new Publisher();
-
     private int keepAliveIntervalMinutes = 5;
 
     /**
@@ -54,80 +52,6 @@ public class PubSubConfigurationProperties {
      */
     public void setKeepAliveIntervalMinutes(int keepAliveIntervalMinutes) {
         this.keepAliveIntervalMinutes = keepAliveIntervalMinutes;
-    }
-
-    /**
-     *
-     * @return publisher configuration
-     */
-    public Publisher getPublisher() {
-        return publisher;
-    }
-
-    /**
-     *
-     * @param publisher configuration
-     */
-    public void setPublisher(Publisher publisher) {
-        this.publisher = publisher;
-    }
-
-    /**
-     * Publisher settings.
-     */
-    @ConfigurationProperties("publisher")
-    public static class Publisher {
-
-        private int executorThreads = 4;
-
-        @ConfigurationBuilder(prefixes = "set", configurationPrefix = "retry")
-        private RetrySettings.Builder retrySettings;
-
-        @ConfigurationBuilder(prefixes = "set", configurationPrefix = "batching")
-        private BatchingSettings.Builder batchingSettings;
-
-        @ConfigurationBuilder(prefixes = "set", configurationPrefix = "flow-control")
-        private FlowControlSettings.Builder flowControlSettings;
-
-        /**
-         * Number of threads used by every publisher.
-         * @return executorThreads
-         */
-        public int getExecutorThreads() {
-            return this.executorThreads;
-        }
-
-        /**
-         * Number of threads used by every publisher.
-         * @param executorThreads
-         */
-        public void setExecutorThreads(int executorThreads) {
-            this.executorThreads = executorThreads;
-        }
-
-        public RetrySettings getRetrySettings() {
-            return retrySettings.build();
-        }
-
-        public void setRetrySettings(RetrySettings.Builder retrySettings) {
-            this.retrySettings = retrySettings;
-        }
-
-        public BatchingSettings getBatchingSettings() {
-            return batchingSettings.build();
-        }
-
-        public void setBatchingSettings(BatchingSettings.Builder batchingSettings) {
-            this.batchingSettings = batchingSettings;
-        }
-
-        public FlowControlSettings getFlowControlSettings() {
-            return flowControlSettings.build();
-        }
-
-        public void setFlowControlSettings(FlowControlSettings.Builder flowControlSettings) {
-            this.flowControlSettings = flowControlSettings;
-        }
     }
 
 }

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PublisherConfigurationProperties.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PublisherConfigurationProperties.java
@@ -1,0 +1,62 @@
+package io.micronaut.gcp.pubsub.configuration;
+
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.retrying.RetrySettings;
+import io.micronaut.context.annotation.ConfigurationBuilder;
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties(PubSubConfigurationProperties.PREFIX + ".publisher")
+public class PublisherConfigurationProperties {
+
+    private int executorThreads = 4;
+
+    @ConfigurationBuilder(prefixes = "set", configurationPrefix = "retry")
+    private RetrySettings.Builder retrySettings = RetrySettings.newBuilder();
+
+    @ConfigurationBuilder(prefixes = "set", configurationPrefix = "batching")
+    private BatchingSettings.Builder batchingSettings = BatchingSettings.newBuilder();
+
+    @ConfigurationBuilder(prefixes = "set", configurationPrefix = "flow-control")
+    private FlowControlSettings.Builder flowControlSettings = FlowControlSettings.newBuilder();
+
+    /**
+     * Number of threads used by every publisher.
+     * @return executorThreads
+     */
+    public int getExecutorThreads() {
+        return this.executorThreads;
+    }
+
+    /**
+     * Number of threads used by every publisher.
+     * @param executorThreads
+     */
+    public void setExecutorThreads(int executorThreads) {
+        this.executorThreads = executorThreads;
+    }
+
+    public RetrySettings.Builder getRetrySettings() {
+        return retrySettings;
+    }
+
+    public void setRetrySettings(RetrySettings.Builder retrySettings) {
+        this.retrySettings = retrySettings;
+    }
+
+    public BatchingSettings.Builder getBatchingSettings() {
+        return batchingSettings;
+    }
+
+    public void setBatchingSettings(BatchingSettings.Builder batchingSettings) {
+        this.batchingSettings = batchingSettings;
+    }
+
+    public FlowControlSettings getFlowControlSettings() {
+        return flowControlSettings.build();
+    }
+
+    public void setFlowControlSettings(FlowControlSettings.Builder flowControlSettings) {
+        this.flowControlSettings = flowControlSettings;
+    }
+}

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/ThreeTenConverterRegistrar.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/ThreeTenConverterRegistrar.java
@@ -1,0 +1,76 @@
+package io.micronaut.gcp.pubsub.configuration;
+
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.core.util.StringUtils;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.Duration;
+
+import javax.inject.Singleton;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Singleton
+public class ThreeTenConverterRegistrar implements TypeConverterRegistrar {
+
+    private static final Pattern DURATION_MATCHER = Pattern.compile("^(-?\\d+)([unsmhd])(s?)$");
+    private static final int MILLIS = 3;
+
+    @Override
+    public void register(ConversionService<?> conversionService) {
+        conversionService.addConverter(
+                CharSequence.class,
+                Duration.class,
+                (object, targetType, context) -> {
+                    String value = object.toString().trim();
+                    if (value.startsWith("P")) {
+                        try {
+                            return Optional.of(Duration.parse(value));
+                        } catch (DateTimeException e) {
+                            context.reject(value, e);
+                            return Optional.empty();
+                        }
+                    } else {
+                        Matcher matcher = DURATION_MATCHER.matcher(value);
+                        if (matcher.find()) {
+                            String amount = matcher.group(1);
+                            final String g2 = matcher.group(2);
+                            char type = g2.charAt(0);
+                            try {
+                                switch (type) {
+                                    case 's':
+                                        return Optional.of(Duration.ofSeconds(Long.valueOf(amount)));
+                                    case 'm':
+                                        String ms = matcher.group(MILLIS);
+                                        if (StringUtils.hasText(ms)) {
+                                            return Optional.of(Duration.ofMillis(Long.valueOf(amount)));
+                                        } else {
+                                            return Optional.of(Duration.ofMinutes(Long.valueOf(amount)));
+                                        }
+                                    case 'h':
+                                        return Optional.of(Duration.ofHours(Long.valueOf(amount)));
+                                    case 'd':
+                                        return Optional.of(Duration.ofDays(Long.valueOf(amount)));
+                                    default:
+                                        final String seq = g2 + matcher.group(3);
+                                        switch (seq) {
+                                            case "ns":
+                                                return Optional.of(Duration.ofNanos(Long.valueOf(amount)));
+                                            default:
+                                                context.reject(
+                                                        value,
+                                                        new DateTimeException("Unparseable date format (" + value + "). Should either be a ISO-8601 duration or a round number followed by the unit type"));
+                                                return Optional.empty();
+                                        }
+                                }
+                            } catch (NumberFormatException e) {
+                                context.reject(value, e);
+                            }
+                        }
+                    }
+                    return Optional.empty();
+                }
+        );
+    }
+}

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -20,6 +20,7 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import io.micronaut.gcp.GoogleCloudConfiguration;
 import io.micronaut.gcp.pubsub.configuration.PubSubConfigurationProperties;
+import io.micronaut.gcp.pubsub.configuration.PublisherConfigurationProperties;
 
 import javax.annotation.Nonnull;
 import javax.inject.Singleton;
@@ -51,15 +52,18 @@ public class DefaultPublisherFactory implements PublisherFactory {
 
     private final PubSubConfigurationProperties pubSubConfigurationProperties;
 
+    private final PublisherConfigurationProperties publisherConfigurationProperties;
     private final GoogleCloudConfiguration googleCloudConfiguration;
 
     public DefaultPublisherFactory(ExecutorProvider executorProvider,
                                    TransportChannelProvider transportChannelProvider,
                                    PubSubConfigurationProperties pubSubConfigurationProperties,
+                                   PublisherConfigurationProperties publisherConfigurationProperties,
                                    GoogleCloudConfiguration googleCloudConfiguration) {
         this.executorProvider = executorProvider;
         this.transportChannelProvider = transportChannelProvider;
         this.pubSubConfigurationProperties = pubSubConfigurationProperties;
+        this.publisherConfigurationProperties = publisherConfigurationProperties;
         this.googleCloudConfiguration = googleCloudConfiguration;
     }
 
@@ -76,12 +80,8 @@ public class DefaultPublisherFactory implements PublisherFactory {
                 if (this.executorProvider != null) {
                     publisherBuilder.setExecutorProvider(this.executorProvider);
                 }
-                if (this.pubSubConfigurationProperties.getPublisher().getRetrySettings() != null) {
-                    publisherBuilder.setRetrySettings(this.pubSubConfigurationProperties.getPublisher().getRetrySettings());
-                }
-                if (this.pubSubConfigurationProperties.getPublisher().getBatchingSettings() != null) {
-                    publisherBuilder.setBatchingSettings(this.pubSubConfigurationProperties.getPublisher().getBatchingSettings());
-                }
+                publisherBuilder.setRetrySettings(publisherConfigurationProperties.getRetrySettings().build());
+                publisherBuilder.setBatchingSettings(publisherConfigurationProperties.getBatchingSettings().build());
                 return publisherBuilder.build();
             } catch (IOException ex) {
                 throw new RuntimeException(ex);

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationSpec.groovy
@@ -8,14 +8,23 @@ import java.time.Duration
 class PubSubConfigurationSpec extends Specification {
 
     void "test configuration binding"() {
-        ApplicationContext ctx = ApplicationContext.run(["gcp.pubsub.publisher.retry.initialRetryDelay" : "10s",
-                "gcp.pubsub.publisher.executorThreads" : "2",
+        ApplicationContext ctx = ApplicationContext.run([
                 "gcp.pubsub.keepAliveIntervalMinutes" : "10"])
         PubSubConfigurationProperties properties = ctx.getBean(PubSubConfigurationProperties)
 
         expect:
-            //properties.publisher.retrySettings.initialRetryDelay.equals(Duration.ofSeconds(10L))
-            properties.publisher.executorThreads == 2
+        properties.keepAliveIntervalMinutes == 10
+    }
+
+    void "test publisher configuration binding"() {
+        ApplicationContext ctx = ApplicationContext.run([
+                "gcp.pubsub.publisher.retry.initial-retry-delay" : "10s",
+                "gcp.pubsub.publisher.executorThreads" : "2"])
+        PublisherConfigurationProperties properties = ctx.getBean(PublisherConfigurationProperties)
+
+        expect:
+        properties.retrySettings.initialRetryDelay.seconds == 10
+        properties.executorThreads == 2
     }
 
 }


### PR DESCRIPTION
Note that there seems to be a limitation in Micronaut that `@ConfigurationBuilder` cannot be used in inner classes. I'm going to create an issue to track that.

The other issue was that the builder was not being instantiated and Micronaut didn't know how to. Also the getter method has to return the builder itself because that is called to retrieve the builder (no reflection via private field) and then call the setters.

After that was corrected I saw that the builders use a custom implementation for Duration, which Micronaut does not know how to handle. I added a converter registrar that will handle constructing the custom Duration type, however other converters may be necessary.